### PR TITLE
AR-1085 : fix fetch task result timeout 

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -2507,7 +2507,6 @@ public class Driver implements IDriver {
       if (fetchTask.getWork().isUsingThriftJDBCBinarySerDe()) {
         maxRows = 1;
       }
-      // we need the max rows at the time of execution in order to fetch them correctly
       fetchTask.setMaxRows(maxRows);
       return fetchTask.fetch(res);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -2133,6 +2133,11 @@ public class Driver implements IDriver {
           tsk.updateTaskMetrics(metrics);
         }
       }
+      // Add fetch tasks to runnable as well
+      if (null != plan.getFetchTask()) {
+        driverCxt.addToRunnable(plan.getFetchTask());
+        plan.getFetchTask().updateTaskMetrics(metrics);
+      }
 
       preExecutionCacheActions();
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -2133,8 +2133,9 @@ public class Driver implements IDriver {
           tsk.updateTaskMetrics(metrics);
         }
       }
-      // Add fetch tasks to runnable as well
-      if (null != plan.getFetchTask()) {
+      // Add fetch tasks to when the plan consists of only a fetch task
+      // i.e. this query has been converted from a regular root task
+      if (null != plan.getFetchTask() && plan.getRootTasks().isEmpty()) {
         driverCxt.addToRunnable(plan.getFetchTask());
         plan.getFetchTask().updateTaskMetrics(metrics);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -2133,8 +2133,9 @@ public class Driver implements IDriver {
           tsk.updateTaskMetrics(metrics);
         }
       }
-      // Add fetch tasks to when the plan consists of only a fetch task
-      // i.e. this query has been converted from a regular root task
+      /* Fetch task should be executed when the plan consists of only a fetch task
+      (i.e. this query has been converted from a regular root task
+      so it should behave like a regular task) */
       if (null != plan.getFetchTask() && plan.getRootTasks().isEmpty()) {
         driverCxt.addToRunnable(plan.getFetchTask());
         plan.getFetchTask().updateTaskMetrics(metrics);

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -2506,6 +2506,7 @@ public class Driver implements IDriver {
       if (fetchTask.getWork().isUsingThriftJDBCBinarySerDe()) {
         maxRows = 1;
       }
+      // we need the max rows at the time of execution in order to fetch them correctly
       fetchTask.setMaxRows(maxRows);
       return fetchTask.fetch(res);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -65,7 +65,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
   @Override
   public void initialize(QueryState queryState, QueryPlan queryPlan, DriverContext ctx,
       CompilationOpContext opContext) {
-    LOG.info("FETCH_TASK: initializing.");
+    LOG.info("initializing.");
     super.initialize(queryState, queryPlan, ctx, opContext);
     work.initializeForFetch(opContext);
 
@@ -108,7 +108,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
 
   @Override
   public int execute(DriverContext driverContext) {
-    LOG.info("FETCH_TASK: pre-fetching.");
+    LOG.info("pre-fetching.");
     // fetch task now is a blocking sync task instead of a delay execution
     // at the time of ResultSet fetch. This eliminates the negative query where
     // the fetch task will hang forever waiting for the result (that is not found)
@@ -116,7 +116,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
     try {
       preFetchedResult = internalFetch(resultSet);
     } catch (IOException e) {
-      throw new RuntimeException("Encountered exception while fetching result set", e);
+      throw new RuntimeException(e);
     }
 
     return 0;
@@ -146,7 +146,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
   public boolean fetch(List res) throws IOException {
     boolean result = preFetchedResult;
     if (result) {
-      LOG.info("FETCH_TASK: using pre-fetched results with " + maxRows + " max rows out of " + resultSet.size() + " total rows.");
+      LOG.info("using pre-fetched results with " + maxRows + " max rows out of " + resultSet.size() + " total rows.");
 
       for (int i = 0; i < Math.min(resultSet.size(), maxRows); i++) {
         res.add(resultSet.get(i));
@@ -163,7 +163,7 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
   }
 
   private boolean internalFetch(List res) throws IOException {
-    LOG.info("FETCH_TASK: begin fetching " + maxRows + " max rows of " + totalRows + "/" + work.getLimit() + " total rows.");
+    LOG.info("begin fetching " + maxRows + " max rows of " + totalRows + "/" + work.getLimit() + " total rows.");
 
     sink.reset(res);
     int rowsRet = work.getLeastNumRows();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -149,7 +149,9 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
 
     sink.reset(res);
 
-    Collections.copy(res, resultSet);
+    for (int i = 0; i < resultSet.size(); i++) {
+      res.add(resultSet.get(i));
+    }
 
     return fetchResult;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -149,14 +149,18 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
 
     sink.reset(res);
 
-    for (int i = 0; i < Math.min(resultSet.size(), maxRows); i++) {
-      res.add(resultSet.get(i));
-    }
-
-    // reset states
-    resultSet = new ArrayList();
     boolean result = fetchResult;
-    fetchResult = false;
+    if (result) {
+      for (int i = 0; i < Math.min(resultSet.size(), maxRows); i++) {
+        res.add(resultSet.get(i));
+      }
+
+      // reset states
+      resultSet = new ArrayList();
+      fetchResult = false;
+    } else {
+      result = internalFetch(res);
+    }
 
     return result;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -148,24 +148,9 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
     LOG.info("FETCH_TASK: using pre-fetched data with " + maxRows + " max rows of " + totalRows + " total rows.");
 
     sink.reset(res);
-    // making sure that fetch(..) behavior remains the same
-    int rowsRet = work.getLeastNumRows();
-    if (rowsRet <= 0) {
-      rowsRet = work.getLimit() >= 0 ? Math.min(work.getLimit() - totalRows, maxRows) : maxRows;
-    }
 
     for (int i = 0; i < Math.min(resultSet.size(), maxRows); i++) {
       res.add(resultSet.get(i));
-    }
-
-    // making sure that fetch(..) behavior remains the same
-    if (rowsRet <= 0 || work.getLimit() == totalRows) {
-      try {
-        fetch.clearFetchContext();
-      } catch (HiveException e) {
-        throw new IOException(e);
-      }
-      return false;
     }
 
     // reset states

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchTask.java
@@ -109,10 +109,10 @@ public class FetchTask extends Task<FetchWork> implements Serializable {
   @Override
   public int execute(DriverContext driverContext) {
     LOG.info("pre-fetching.");
-    // fetch task now is a blocking sync task instead of a delay execution
-    // at the time of ResultSet fetch. This eliminates the negative query where
-    // the fetch task will hang forever waiting for the result (that is not found)
 
+    /* Fetch task could take a long time if there's no result. This pre-fetching ensures
+    that if the "no result case" ever happens, the users will see their query in running
+    status instead of completed immediately */
     try {
       preFetchedResult = internalFetch(resultSet);
     } catch (IOException e) {


### PR DESCRIPTION
* When a query is converted to a fetch task and the predicate always return false (there's no value matching the predicate), then the fetch result would likely cause a network timeout (60s for a front-end web application)
* Furthermore, it is impossible to cancel a fetch task since it doesn't have an operation handle similar to a regular M/R or TEZ task. The solution is to pre-fetch the data during task.execute(). This allows us to handle the no result cases better since the operation will be blocking and the users could cancel it.